### PR TITLE
[Applications] Show detected markers in video and live mode

### DIFF
--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -116,7 +116,7 @@ void CmdLine::usage( const char* const argv0 )
           "           [--use-cuda]\n"
           "           [--parallel <n>]\n"
           "\n"
-          "    <imgpath>  - path to an image (JPG, PNG) or video(avi, mov) or camera index for live capture (0, 1...)\n"
+          "    <imgpath>  - path to an image (JPG, PNG) or video (avi, mov) or camera index for live capture (0, 1...)\n"
           "    <nbrings>  - number of rings of the CCTags to detect\n"
           "    <bankpath> - path to a bank parameter file, e.g. 4Crowns/ids.txt \n"
           "    <output>   - output folder name \n"

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -116,7 +116,7 @@ void CmdLine::usage( const char* const argv0 )
           "           [--use-cuda]\n"
           "           [--parallel <n>]\n"
           "\n"
-          "    <imgpath>  - path to an image (JPG, PNG) or video\n"
+          "    <imgpath>  - path to an image (JPG, PNG) or video(avi, mov) or camera index for live capture (0, 1...)\n"
           "    <nbrings>  - number of rings of the CCTags to detect\n"
           "    <bankpath> - path to a bank parameter file, e.g. 4Crowns/ids.txt \n"
           "    <output>   - output folder name \n"

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -113,7 +113,7 @@ void detection(std::size_t frameId,
   std::size_t i = 0;
   std::size_t nMarkers = 0;
   output << "#frame " << frameId << '\n';
-  output << markers.size() << '\n';
+  output << "Detected " << markers.size() << " candidates" << '\n';
 
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -58,7 +58,7 @@ namespace bfs = boost::filesystem;
  * @param[in] s The string to check.
  * @return Return true if the string is an integer number
  */
-bool isInteger(std::string s)
+bool isInteger(std::string &s)
 {
   std::regex e("^-?\\d+");
   return std::regex_match(s, e);

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -118,6 +118,14 @@ void detection(std::size_t frameId,
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {
     output << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
+    ++i;
+    if(marker.getStatus() == 1)
+      ++nMarkers;
+  }
+  
+  i = 0;
+  BOOST_FOREACH(const cctag::CCTag & marker, markers)
+  {
     if(i == 0)
     {
       CCTAG_COUT_NOENDL(marker.id() + 1);
@@ -127,8 +135,6 @@ void detection(std::size_t frameId,
       CCTAG_COUT_NOENDL(", " << marker.id() + 1);
     }
     ++i;
-    if(marker.getStatus() == 1)
-      ++nMarkers;
   }
 
   std::cout << std::endl << nMarkers << " markers detected and identified" << std::endl;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -239,7 +239,14 @@ int main(int argc, char** argv)
     ia >> boost::serialization::make_nvp("CCTagsParams", params);
     CCTAG_COUT(params._nCrowns);
     CCTAG_COUT(nCrowns);
-    assert(nCrowns == params._nCrowns);
+    if(nCrowns != params._nCrowns)
+    {
+      std::cerr << std::endl
+              << "The number of rings is inconsistent between the parameter file (" 
+              << params._nCrowns << ") and the command line (" 
+              << nCrowns << ")" << std::endl;
+      return EXIT_FAILURE;
+    }
   }
   else
   {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -94,13 +94,26 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
   }
 }
 
+/**
+ * @brief Extract the cctag from an image.
+ * 
+ * @param[in] frameId The number of the frame.
+ * @param[in] pipeId The pipe id (used for multiple streams).
+ * @param[in] src The image to process.
+ * @param[in] params The parameters for the detection.
+ * @param[in] bank The marker bank.
+ * @param[out] markers The list of detected markers.
+ * @param[out] outStream The output stream on which to write debug information.
+ * @param[out] debugFileName The filename for the image to save with the detected 
+ * markers.
+ */
 void detection(std::size_t frameId,
                int pipeId,
                const cv::Mat & src,
                const cctag::Parameters & params,
                const cctag::CCTagMarkersBank & bank,
                boost::ptr_list<CCTag> &markers,
-               std::ostream & output,
+               std::ostream & outStream,
                std::string debugFileName = "")
 {
 
@@ -136,12 +149,12 @@ void detection(std::size_t frameId,
 
   std::size_t counter = 0;
   std::size_t nMarkers = 0;
-  output << "#frame " << frameId << '\n';
-  output << "Detected " << markers.size() << " candidates" << '\n';
+  outStream << "#frame " << frameId << '\n';
+  outStream << "Detected " << markers.size() << " candidates" << '\n';
 
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {
-    output << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
+    outStream << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
     ++counter;
     if(marker.getStatus() == 1)
       ++nMarkers;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -325,6 +325,6 @@ int main(int argc, char** argv)
       throw std::logic_error("Unrecognized input.");
   }
   outputFile.close();
-  return 0;
+  return EXIT_SUCCESS;
 }
 

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -51,6 +51,25 @@ using boost::timer;
 using namespace boost::gil;
 namespace bfs = boost::filesystem;
 
+void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
+{
+  BOOST_FOREACH(const cctag::CCTag & marker, markers)
+  {
+    if(marker.getStatus() == 1)
+    {
+      cv::circle(image, cv::Point(marker.x(), marker.y()), 10, cv::Scalar(0, 255, 0 , 255), 3);
+      cv::putText(image, std::to_string(marker.id()), cv::Point(marker.x(), marker.y()), cv::FONT_HERSHEY_SIMPLEX, 5, cv::Scalar(0, 255, 0, 255), 3);
+    }
+    else
+    {
+      cv::circle(image, cv::Point(marker.x(), marker.y()), 10, cv::Scalar(0, 0, 255 , 255), 2);
+      cv::putText(image, std::to_string(marker.id()), cv::Point(marker.x(), marker.y()), cv::FONT_HERSHEY_SIMPLEX, 4, cv::Scalar(0, 0, 255, 255), 3);
+      
+    }
+
+  }
+}
+
 void detection(std::size_t frameId,
                int pipeId,
                const cv::Mat & src,

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -51,20 +51,31 @@ using boost::timer;
 using namespace boost::gil;
 namespace bfs = boost::filesystem;
 
+/**
+ * @brief Draw the detected marker int the given image. The markers are drawn as a
+ * circle centered in the center of the marker and with its id. It draws the 
+ * well identified markers in green, the unknown / badly detected markers in red.
+ * 
+ * @param[in] markers The list of markers to draw.
+ * @param[out] image The image in which to draw the markers.
+ */
 void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
 {
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {
+    const cv::Point center = cv::Point(marker.x(), marker.y());
+    const int radius = 10;
     if(marker.getStatus() == 1)
     {
-      cv::circle(image, cv::Point(marker.x(), marker.y()), 10, cv::Scalar(0, 255, 0 , 255), 3);
-      cv::putText(image, std::to_string(marker.id()), cv::Point(marker.x(), marker.y()), cv::FONT_HERSHEY_SIMPLEX, 5, cv::Scalar(0, 255, 0, 255), 3);
+      const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
+      cv::circle(image, center, radius, color, 3);
+      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, 5, color, 3);
     }
     else
     {
-      cv::circle(image, cv::Point(marker.x(), marker.y()), 10, cv::Scalar(0, 0, 255 , 255), 2);
-      cv::putText(image, std::to_string(marker.id()), cv::Point(marker.x(), marker.y()), cv::FONT_HERSHEY_SIMPLEX, 4, cv::Scalar(0, 0, 255, 255), 3);
-      
+      const cv::Scalar color = cv::Scalar(0, 0, 255 , 255);
+      cv::circle(image, center, radius, color, 2);
+      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, 4, color, 3);
     }
 
   }

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -110,7 +110,7 @@ void detection(std::size_t frameId,
   std::cout << "Total time: " << t.elapsed() << std::endl;
   CCTAG_COUT_NOENDL("Id : ");
 
-  std::size_t i = 0;
+  std::size_t counter = 0;
   std::size_t nMarkers = 0;
   output << "#frame " << frameId << '\n';
   output << "Detected " << markers.size() << " candidates" << '\n';
@@ -118,15 +118,15 @@ void detection(std::size_t frameId,
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {
     output << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
-    ++i;
+    ++counter;
     if(marker.getStatus() == 1)
       ++nMarkers;
   }
   
-  i = 0;
+  counter = 0;
   BOOST_FOREACH(const cctag::CCTag & marker, markers)
   {
-    if(i == 0)
+    if(counter == 0)
     {
       CCTAG_COUT_NOENDL(marker.id() + 1);
     }
@@ -134,7 +134,7 @@ void detection(std::size_t frameId,
     {
       CCTAG_COUT_NOENDL(", " << marker.id() + 1);
     }
-    ++i;
+    ++counter;
   }
 
   std::cout << std::endl << nMarkers << " markers detected and identified" << std::endl;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -363,8 +363,6 @@ int main(int argc, char** argv)
       else
         frame.copyTo(imgGray);
 
-      boost::timer t;
-
       // Set the output folder
       std::stringstream outFileName;
       outFileName << std::setfill('0') << std::setw(5) << frameId;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -236,7 +236,6 @@ int main(int argc, char** argv)
   bfs::path myPath(cmdline._filename);
   std::string ext(myPath.extension().string());
 
-  const bfs::path subFilenamePath(myPath.filename());
   const bfs::path parentPath(myPath.parent_path() == "" ? "." : myPath.parent_path());
   std::string outputFileName;
   if(!bfs::is_directory(myPath))

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     }
 
     // Read the parameter file provided by the user
-    std::ifstream ifs(cmdline._paramsFilename.c_str());
+    std::ifstream ifs(cmdline._paramsFilename);
     boost::archive::xml_iarchive ia(ifs);
     ia >> boost::serialization::make_nvp("CCTagsParams", params);
     CCTAG_COUT(params._nCrowns);
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
   {
     // Use the default parameters and save them in defaultParameters.xml
     cmdline._paramsFilename = "defaultParameters.xml";
-    std::ofstream ofs(cmdline._paramsFilename.c_str());
+    std::ofstream ofs(cmdline._paramsFilename);
     boost::archive::xml_oarchive oa(ofs);
     oa << boost::serialization::make_nvp("CCTagsParams", params);
     CCTAG_COUT("Parameter file not provided. Default parameters are used.");
@@ -272,7 +272,7 @@ int main(int argc, char** argv)
     POP_INFO("looking at video " << myPath.string());
 
     // open video and check
-    cv::VideoCapture video(cmdline._filename.c_str());
+    cv::VideoCapture video(cmdline._filename);
     if(!video.isOpened())
     {
       CCTAG_COUT("Unable to open the video : " << cmdline._filename);

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -324,6 +324,10 @@ int main(int argc, char** argv)
 
     std::cerr << "Starting to read video frames" << std::endl;
     std::size_t frameId = 0;
+    
+    // time to wait in milliseconds for keyboard input, used to switch from
+    // live to debug mode
+    int delay = 10;
 
     while(true)
     {
@@ -365,9 +369,17 @@ int main(int argc, char** argv)
       
       drawMarkers(markers, frame);
       cv::imshow(windowName, frame);
+      if( cv::waitKey(delay) == 27 ) break;
+      char key = (char) cv::waitKey(delay);
       // stop capturing by pressing ESC
-      if( cv::waitKey() == 27 ) break;
-
+      if(key == 27) 
+        break;
+      if(key == 'l' || key == 'L')
+        delay = 10;
+      // delay = 0 will wait for a key to be pressed
+      if(key == 'd' || key == 'D')
+        delay = 0;
+      
       ++frameId;
     }
 

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -277,11 +277,11 @@ int main(int argc, char** argv)
   popart::device_prop_t deviceInfo(false);
 #endif // WITH_CUDA
 
-  bfs::path myPath(cmdline._filename);
+  bfs::path myPath(bfs::absolute(cmdline._filename));
   std::string ext(myPath.extension().string());
   boost::algorithm::to_lower(ext);
 
-  const bfs::path parentPath(myPath.parent_path() == "" ? "." : myPath.parent_path());
+  const bfs::path parentPath(myPath.parent_path());
   std::string outputFileName;
   if(!bfs::is_directory(myPath))
   {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
     {
       useCamera = true;
     }
-    else if(!boost::filesystem::exists(cmdline._filename))
+    else if(!bfs::exists(cmdline._filename))
     {
       std::cerr << std::endl
               << "The input file \"" << cmdline._filename << "\" is missing" << std::endl;
@@ -226,7 +226,7 @@ int main(int argc, char** argv)
 
   if(!cmdline._paramsFilename.empty())
   {
-    if(!boost::filesystem::exists(cmdline._paramsFilename))
+    if(!bfs::exists(cmdline._paramsFilename))
     {
       std::cerr << std::endl
               << "The input file \"" << cmdline._paramsFilename << "\" is missing" << std::endl;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -77,17 +77,18 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
   {
     const cv::Point center = cv::Point(marker.x(), marker.y());
     const int radius = 10;
+    const int fontSize = 3;
     if(marker.getStatus() == status::id_reliable)
     {
       const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
       cv::circle(image, center, radius, color, 3);
-      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, 5, color, 3);
+      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
     }
     else
     {
       const cv::Scalar color = cv::Scalar(0, 0, 255 , 255);
       cv::circle(image, center, radius, color, 2);
-      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, 4, color, 3);
+      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
     }
 
   }

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -179,10 +179,10 @@ int main(int argc, char** argv)
 #endif
 
   // Check the (optional) parameters path
-  std::size_t nCrowns = std::atoi(cmdline._nCrowns.c_str());
+  const std::size_t nCrowns = std::atoi(cmdline._nCrowns.c_str());
   cctag::Parameters params(nCrowns);
 
-  if(cmdline._paramsFilename != "")
+  if(!cmdline._paramsFilename.empty())
   {
     if(!boost::filesystem::exists(cmdline._paramsFilename))
     {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -179,11 +179,17 @@ int main(int argc, char** argv)
   }
 
   cmdline.print(argv[0]);
+  
+  bool useCamera = false;
 
   // Check input path
   if(!cmdline._filename.empty())
   {
-    if(!boost::filesystem::exists(cmdline._filename))
+    if(isInteger(cmdline._filename))
+    {
+      useCamera = true;
+    }
+    else if(!boost::filesystem::exists(cmdline._filename))
     {
       std::cerr << std::endl
               << "The input file \"" << cmdline._filename << "\" is missing" << std::endl;
@@ -295,13 +301,18 @@ int main(int argc, char** argv)
     detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif
   }
-  else if(ext == ".avi" || ext == ".mov")
+  else if(ext == ".avi" || ext == ".mov" || useCamera)
   {
     CCTAG_COUT("*** Video mode ***");
     POP_INFO("looking at video " << myPath.string());
 
     // open video and check
-    cv::VideoCapture video(cmdline._filename);
+    cv::VideoCapture video;
+    if(useCamera)
+      video.open(std::atoi(cmdline._filename.c_str()));
+    else
+      video.open(cmdline._filename);
+    
     if(!video.isOpened())
     {
       CCTAG_COUT("Unable to open the video : " << cmdline._filename);

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -41,7 +41,6 @@
 #include <string>
 #include <fstream>
 #include <exception>
-#include <regex>
 
 #include <tbb/tbb.h>
 
@@ -61,8 +60,7 @@ namespace bfs = boost::filesystem;
  */
 bool isInteger(std::string &s)
 {
-  std::regex e("^-?\\d+");
-  return std::regex_match(s, e);
+  return (s.size() == 1 && std::isdigit(s[0]));
 }
 
 /**

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -258,7 +258,7 @@ int main(int argc, char** argv)
 
     POP_INFO("looking at image " << myPath.string());
 
-    // Gray scale convertion
+    // Gray scale conversion
     cv::Mat src = cv::imread(cmdline._filename);
     cv::Mat graySrc;
     cv::cvtColor(src, graySrc, CV_BGR2GRAY);

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -29,6 +29,7 @@
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/algorithm/algorithm.hpp>
 
 #include <opencv/cv.h>
 #include <opencv2/videoio.hpp>
@@ -278,6 +279,7 @@ int main(int argc, char** argv)
 
   bfs::path myPath(cmdline._filename);
   std::string ext(myPath.extension().string());
+  boost::algorithm::to_lower(ext);
 
   const bfs::path parentPath(myPath.parent_path() == "" ? "." : myPath.parent_path());
   std::string outputFileName;
@@ -294,7 +296,7 @@ int main(int argc, char** argv)
   std::ofstream outputFile;
   outputFile.open(outputFileName);
 
-  if((ext == ".png") || (ext == ".jpg") || (ext == ".PNG") || (ext == ".JPG"))
+  if((ext == ".png") || (ext == ".jpg"))
   {
 
     std::cout << "******************* Image mode **********************" << std::endl;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -29,7 +29,7 @@
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/algorithm/algorithm.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 #include <opencv/cv.h>
 #include <opencv2/videoio.hpp>

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
 {
   CmdLine cmdline;
 
-  if(cmdline.parse(argc, argv) == false)
+  if(!cmdline.parse(argc, argv))
   {
     cmdline.usage(argv[0]);
     return EXIT_FAILURE;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
   cmdline.print(argv[0]);
 
   // Check input path
-  if(cmdline._filename.compare("") != 0)
+  if(!cmdline._filename.empty())
   {
     if(!boost::filesystem::exists(cmdline._filename))
     {
@@ -266,7 +266,7 @@ int main(int argc, char** argv)
     detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif
   }
-  else if(ext == ".avi")
+  else if(ext == ".avi" || ext == ".mov")
   {
     CCTAG_COUT("*** Video mode ***");
     POP_INFO("looking at video " << myPath.string());

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -56,6 +56,7 @@ void detection(std::size_t frameId,
                const cv::Mat & src,
                const cctag::Parameters & params,
                const cctag::CCTagMarkersBank & bank,
+               boost::ptr_list<CCTag> &markers,
                std::ostream & output,
                std::string debugFileName = "")
 {
@@ -67,7 +68,6 @@ void detection(std::size_t frameId,
 
   // Process markers detection
   boost::timer t;
-  boost::ptr_list<CCTag> markers;
 
   CCTagVisualDebug::instance().initBackgroundImage(src);
   CCTagVisualDebug::instance().setImageFileName(debugFileName);
@@ -240,10 +240,11 @@ int main(int argc, char** argv)
     cv::cvtColor(src, graySrc, CV_BGR2GRAY);
 
     const int pipeId = 0;
+    boost::ptr_list<CCTag> markers;
 #ifdef PRINT_TO_CERR
-    detection(0, pipeId, graySrc, params, bank, std::cerr, myPath.stem().string());
+    detection(0, pipeId, graySrc, params, bank, markers, std::cerr, myPath.stem().string());
 #else
-    detection(0, pipeId, graySrc, params, bank, outputFile, myPath.stem().string());
+    detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif
   }
   else if(ext == ".avi")
@@ -288,6 +289,8 @@ int main(int argc, char** argv)
       // Set the output folder
       std::stringstream outFileName;
       outFileName << std::setfill('0') << std::setw(5) << frameId;
+      
+      boost::ptr_list<CCTag> markers;
 
       // Invert the image for the projection scenario
       //cv::Mat imgGrayInverted;
@@ -296,9 +299,9 @@ int main(int argc, char** argv)
       // Call the CCTag detection
       const int pipeId = 0;
 #ifdef PRINT_TO_CERR
-      detection(frameId, pipeId, *imgGray, params, bank, std::cerr, outFileName.str());
+      detection(frameId, pipeId, *imgGray, params, bank, markers, std::cerr, outFileName.str());
 #else
-      detection(frameId, pipeId, *imgGray, params, bank, outputFile, outFileName.str());
+      detection(frameId, pipeId, *imgGray, params, bank, markers, outputFile, outFileName.str());
 #endif
       ++frameId;
       if(frameId % 100 == 0)
@@ -345,10 +348,11 @@ int main(int argc, char** argv)
 
           // Call the CCTag detection
           int pipeId = (fileInFolder.first & 1);
+          boost::ptr_list<CCTag> markers;
 #ifdef PRINT_TO_CERR
-          detection(fileInFolder.first, pipeId, imgGray, params, bank, std::cerr, fileInFolder.second.stem().string());
+          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, std::cerr, fileInFolder.second.stem().string());
 #else
-          detection(fileInFolder.first, pipeId, imgGray, params, bank, outputFile, fileInFolder.second.stem().string());
+          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, outputFile, fileInFolder.second.stem().string());
 #endif
           std::cerr << "Done processing image " << fileInFolder.second.string() << std::endl;
         }

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -116,7 +116,7 @@ void detection(std::size_t frameId,
                std::string debugFileName = "")
 {
 
-  if(debugFileName == "")
+  if(debugFileName.empty())
   {
     debugFileName = "00000";
   }
@@ -267,7 +267,7 @@ int main(int argc, char** argv)
     params.setUseCuda(false);
   }
 
-  if(cmdline._debugDir != "")
+  if(!cmdline._debugDir.empty())
   {
     params.setDebugDir(cmdline._debugDir);
   }

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -91,8 +91,8 @@ void detection(std::size_t frameId,
   std::cout << "Total time: " << t.elapsed() << std::endl;
   CCTAG_COUT_NOENDL("Id : ");
 
-  int i = 0;
-  int nMarkers = 0;
+  std::size_t i = 0;
+  std::size_t nMarkers = 0;
   output << "#frame " << frameId << '\n';
   output << markers.size() << '\n';
 

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -40,6 +40,7 @@
 #include <string>
 #include <fstream>
 #include <exception>
+#include <regex>
 
 #include <tbb/tbb.h>
 
@@ -50,6 +51,18 @@ using boost::timer;
 
 using namespace boost::gil;
 namespace bfs = boost::filesystem;
+
+/**
+ * @brief Check if a string is an integer number.
+ * 
+ * @param[in] s The string to check.
+ * @return Return true if the string is an integer number
+ */
+bool isInteger(std::string s)
+{
+  std::regex e("^-?\\d+");
+  return std::regex_match(s, e);
+}
 
 /**
  * @brief Draw the detected marker int the given image. The markers are drawn as a

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     if(!video.isOpened())
     {
       CCTAG_COUT("Unable to open the video : " << cmdline._filename);
-      return -1;
+      return EXIT_FAILURE;
     }
 
     // play loop

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -73,7 +73,7 @@ bool isInteger(std::string &s)
  */
 void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
 {
-  BOOST_FOREACH(const cctag::CCTag & marker, markers)
+  for(const cctag::CCTag & marker : markers)
   {
     const cv::Point center = cv::Point(marker.x(), marker.y());
     const int radius = 10;
@@ -151,7 +151,7 @@ void detection(std::size_t frameId,
   outStream << "#frame " << frameId << '\n';
   outStream << "Detected " << markers.size() << " candidates" << '\n';
 
-  BOOST_FOREACH(const cctag::CCTag & marker, markers)
+  for(const cctag::CCTag & marker : markers)
   {
     outStream << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
     ++counter;
@@ -160,7 +160,7 @@ void detection(std::size_t frameId,
   }
   
   counter = 0;
-  BOOST_FOREACH(const cctag::CCTag & marker, markers)
+  for(const cctag::CCTag & marker : markers)
   {
     if(counter == 0)
     {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -78,7 +78,7 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
   {
     const cv::Point center = cv::Point(marker.x(), marker.y());
     const int radius = 10;
-    if(marker.getStatus() == 1)
+    if(marker.getStatus() == status::id_reliable)
     {
       const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
       cv::circle(image, center, radius, color, 3);
@@ -156,7 +156,7 @@ void detection(std::size_t frameId,
   {
     outStream << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
     ++counter;
-    if(marker.getStatus() == 1)
+    if(marker.getStatus() == status::id_reliable)
       ++nMarkers;
   }
   


### PR DESCRIPTION
Modified the `detection.cpp` example so that you can see the detected markers on a UI (similar to appCutie) when using a video (and I added the support for webcams)

* some code cleaning
* no more saving all the video frames before processing them
* added .mov as video format
* support for live acquisition (eg usb webcam) with opencv
* two modes, live (default) and debug (it waits for a key to be pressed to move forward); switch from one to another by pressing 'l'/'L' (live) and 'd'/'D' (debug)